### PR TITLE
Kan 12 response request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 en.subject.pdf
+
+/tests

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ CYAN = \033[0;96m
 
 # Sources
 SRCS = \
-	main.cpp
+	main.cpp \
+	ResponseCodes.cpp
 
 OBJS := $(SRCS:%.cpp=$(OBJ_DIR)%.o)
 DEPS = $(SRCS:%.cpp=$(OBJ_DIR)%.d)

--- a/include/ResponseCodes.hpp
+++ b/include/ResponseCodes.hpp
@@ -1,0 +1,27 @@
+#ifndef RESPONSECODES_HPP
+# define RESPONSECODES_HPP
+
+# include <map>
+# include <string>
+
+class	ResponseCodes {
+
+	private:
+		ResponseCodes( void );
+		ResponseCodes( const ResponseCodes& to_copy );
+		~ResponseCodes( void );
+		ResponseCodes&	operator=( const ResponseCodes& to_copy );
+
+		/* PRIVATE METHODS AND MEMBERS */
+		static std::map<int, std::string>	codes_;
+
+		static void	intialize_codes( void );
+
+	public:
+		/* PUBLIC METHODS */
+		static std::string	getCodeElementBody( int code );
+		static std::string	getCodeStatusLine( int code );
+		static std::string	getCombinedStatusLineAndBody( int code );
+};
+
+#endif

--- a/srcs/ResponseCodes.cpp
+++ b/srcs/ResponseCodes.cpp
@@ -1,0 +1,67 @@
+
+#include "ResponseCodes.hpp"
+
+std::map<int, std::string> ResponseCodes::codes_;
+
+/* CONSTRUCTORS */
+
+ResponseCodes::ResponseCodes( void ) { /* default constructor */ }
+
+ResponseCodes::ResponseCodes( const ResponseCodes& to_copy ) {
+
+	*this = to_copy;
+} 
+
+/* DESTRUCTOR */
+
+ResponseCodes::~ResponseCodes( void ) {	/* destructor */ } 
+
+/* OPERATOR OVERLOADS */
+
+ResponseCodes&	ResponseCodes::operator=( const ResponseCodes& rhs ) {
+
+	if (this != &rhs ) {
+		return (*this);
+	}
+	return (*this);
+}
+
+/* CLASS PUBLIC METHODS */
+
+std::string	ResponseCodes::getCodeStatusLine( int code ) {
+
+	if (ResponseCodes::codes_.empty())
+		ResponseCodes::intialize_codes();
+	if (ResponseCodes::codes_[code].empty())
+		return ("HTTP/1.1 500 Internal Server Error\r\n");
+	std::string element = "HTTP/1.1 " + std::to_string(code) + " " + ResponseCodes::codes_[code] + "\r\n";
+	return (element);
+}
+
+std::string	ResponseCodes::getCodeElementBody( int code ) {
+
+	if (ResponseCodes::codes_.empty())
+		ResponseCodes::intialize_codes();
+	std::string message = ResponseCodes::codes_[code];
+	if (message.empty())
+		message = "Unknown Error";
+	std::string element = "\r\n<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<title>" + std::to_string(code) + " ";
+	element += message + "</title>\n</head>\n<body>\n<h1>" + std::to_string(code) + " " + message + "</h1>\n</body>\n</html>\r\n";
+	return (element);
+}
+
+std::string	ResponseCodes::getCombinedStatusLineAndBody( int code ) {
+
+	if (ResponseCodes::codes_.empty())
+		ResponseCodes::intialize_codes();
+	std::string element = ResponseCodes::getCodeStatusLine(code) + ResponseCodes::getCodeElementBody(code);
+	return (element);
+}
+
+/* CLASS PRIVATE METHODS */
+
+void	ResponseCodes::intialize_codes( void ) {
+
+	ResponseCodes::codes_[501] = "Not Implemented";
+	ResponseCodes::codes_[404] = "Not Found";
+}


### PR DESCRIPTION
Initial Class for response codes. has hardcoded 404, 501 codes, all else will show as internal server error. No documentation added yet. 
- This class is static.
- Three public methods:
     - ResponseCodes::getCodeStatusLineResponseCodes::getCodeStatusLine( int code ); => get just the status line (first line of http response)
     - ResponseCodes::getCodeElementBody( int code ); => get just the html element body with the response code as header and page title
     - ResponseCodes::getCombinedStatusLineAndBody( int code); => gets both response code and body combined.
     
  This MVP of the class needs to be tested with the socket to check the formatting of the strings it produces.