### PR TITLE
Kan 6 request parser mvp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ CYAN = \033[0;96m
 # Sources
 SRCS = \
 	main.cpp \
-	ResponseCodes.cpp
+	ResponseCodes.cpp \
+	Request.cpp \
 
 OBJS := $(SRCS:%.cpp=$(OBJ_DIR)%.o)
 DEPS = $(SRCS:%.cpp=$(OBJ_DIR)%.d)

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -29,7 +29,6 @@ class	Request {
 
 	public:
 		Request( void ); // itialize to default values
-		// Request( /*add parameters*/ ); // no paramertized constructor for now
 		Request( const Request& to_copy );
 
 		~Request( void );

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -21,9 +21,9 @@ class	Request {
 		std::map<std::string, std::string>	body_; //body of the request, should it be a map?
 		//no footers for now
 
-		void	parseRequestLine_( std::string to_parse );
-		void	parseHeader_( std::string to_parse );
-		void	parseBody_( std::string to_parse );
+		void	parseRequestLine_( std::string& to_parse );
+		void	parseHeader_( std::string& to_parse );
+		void	parseBody_( std::string& to_parse );
 
 
 

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -1,0 +1,66 @@
+#ifndef REQUEST_HPP
+# define REQUEST_HPP
+
+# include <iostream>
+# include <sstream>
+# include <map>
+
+# define CRLF "\r\n" //make this project wide?
+
+class	Request {
+
+	private:
+		/* PRIVATE METHODS AND MEMBERS */
+		// things I think will be good to have a s a quick reference for the request handling
+		int									size_;
+		bool 								chunked_;
+		bool								keep_alive_;
+		bool								headers_complete;
+		std::map<std::string, std::string>	request_line_; // method, uri, version
+		std::map<std::string, std::string>	headers_; //host, content-type, user-agent, content-egth, last-modified, PRAGMA, accept-encoding accept, connection, reffer, etc.
+		std::map<std::string, std::string>	body_; //body of the request, should it be a map?
+		//no footers for now
+
+		void	parseRequestLine_( std::string to_parse );
+		void	parseHeader_( std::string to_parse );
+		void	parseBody_( std::string to_parse );
+
+
+
+	public:
+		Request( void ); // itialize to default values
+		// Request( /*add parameters*/ ); // no paramertized constructor for now
+		Request( const Request& to_copy );
+
+		~Request( void );
+
+		Request&	operator=( const Request& to_copy );
+
+		/* PUBLIC METHODS */
+		void	add( std::string to_add ); //add to any part of the response, will direct to correct private parsing function
+		void	clear( void ); //clear all data in the request
+
+		/* GETTERS */
+		int		getSize( void ) const;
+		bool	getChunked( void ) const;
+		bool	getKeepAlive( void ) const;
+};
+
+#endif
+
+/* Request */
+// Get /mysite/index.html HTTP/1.1\r\n
+// Host: 10.101.101.10\r\n
+// Accept: */*\r\n
+// \r\n
+
+/* Response */
+// HTTP/1.1 200 OK\r\n
+// Content-Length: 55\r\n
+// Content-Type: text/html\r\n
+// Last-Modified: Wed, 12 Aug 1998 15:03:50 GMT\r\n
+// Accept-Ranges: bytes\r\n
+// ETag: “04f97692cbd1:377”\r\n
+// Date: Thu, 19 Jun 2008 19:29:07 GMT\r\n
+// \r\n
+// <55-character response>

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -1,0 +1,120 @@
+
+#include "Request.hpp"
+
+/* CONSTRUCTORS */
+
+Request::Request( void ) 
+: size_(0), chunked_(false), keep_alive_(false), headers_complete(false) {
+
+	/* default constructor */
+}
+
+// Request::Request( /*add parameters*/ ) {
+
+// 	/* parameterized constructor */
+// }
+
+Request::Request( const Request& to_copy ) {
+
+	*this = to_copy;
+} 
+
+/* DESTRUCTOR */
+
+Request::~Request( void ) {
+
+	/* destructor */
+} 
+
+/* OPERATOR OVERLOADS */
+
+Request&	Request::operator=( const Request& rhs ) {
+
+	if (this != &rhs ) {
+		this->size_ = rhs.size_;
+		this->chunked_ = rhs.chunked_;
+		this->keep_alive_ = rhs.keep_alive_;
+		this->request_line_ = rhs.request_line_;
+		this->headers_ = rhs.headers_;
+		this->body_ = rhs.body_;
+	}
+	return (*this);
+}
+
+/* CLASS PUBLIC METHODS */
+
+/* Request */
+// Get /mysite/index.html HTTP/1.1\r\n
+// Host: 10.101.101.10\r\n
+// Accept: */*\r\n
+// \r\n
+
+/* Response */
+// HTTP/1.1 200 OK\r\n
+// Content-Length: 55\r\n
+// Content-Type: text/html\r\n
+// Last-Modified: Wed, 12 Aug 1998 15:03:50 GMT\r\n
+// Accept-Ranges: bytes\r\n
+// ETag: “04f97692cbd1:377”\r\n
+// Date: Thu, 19 Jun 2008 19:29:07 GMT\r\n
+// \r\n
+// <55-character response>
+
+void	Request::add( std::string to_add ) { //add to any part of the Request, will direct to correct private parsing function
+	
+	std::stringstream	ss(to_add);
+	std::string			line;
+
+	while (getline(ss, line, '\n')) { // do I need my own getline??
+		line += "\n";
+		if (this->request_line_.empty()) {
+			this->parseRequestLine_(line);
+		}
+		else if (this->headers_complete == false) {
+			if (line.compare(CRLF) == 0) {
+				this->headers_complete = true;
+				continue ;
+			}
+			else {
+				this->parseHeader_(line);
+			}
+		}
+		else if (this->headers_complete && line.compare(CRLF) == 0) {
+			break ;
+		}
+		else {
+			this->parseBody_(line);
+		}
+	}
+	std::cout << "Parsing complete!!!!" << std::endl;//
+}
+
+void	Request::clear( void ) { //clear all data in the request
+
+	this->size_ = 0;
+	this->chunked_ = false;
+	this->keep_alive_ = false;
+	this->headers_complete = false;
+	this->request_line_.clear();
+	this->headers_.clear();
+	this->body_.clear();
+}
+/* CLASS PRIVATE METHODS */
+
+void	Request::parseRequestLine_( std::string to_parse ) {
+
+	std::cout << "REQUEST LINE: " << to_parse << std::endl;
+	this->request_line_["test"] = to_parse;
+}
+
+//save specific values for easy access
+
+void	Request::parseHeader_( std::string to_parse ) {
+
+	std::cout << "HEADER: " << to_parse << std::endl;
+}
+
+void	Request::parseBody_( std::string to_parse ) {
+
+	std::cout << "BODY: " << to_parse << std::endl;
+}

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -38,6 +38,7 @@ Request&	Request::operator=( const Request& rhs ) {
 
 /* CLASS PUBLIC METHODS */
 
+/* EXAMPLES */
 /* Request */
 // Get /mysite/index.html HTTP/1.1\r\n
 // Host: 10.101.101.10\r\n
@@ -94,9 +95,10 @@ void	Request::clear( void ) { //clear all data in the request
 	this->headers_.clear();
 	this->body_.clear();
 }
+
 /* CLASS PRIVATE METHODS */
 
-void	Request::parseRequestLine_( std::string to_parse ) {
+void	Request::parseRequestLine_( std::string& to_parse ) {
 
 	std::cout << "REQUEST LINE: " << to_parse << std::endl;
 	this->request_line_["test"] = to_parse;
@@ -104,12 +106,12 @@ void	Request::parseRequestLine_( std::string to_parse ) {
 
 //save specific values for easy access
 
-void	Request::parseHeader_( std::string to_parse ) {
+void	Request::parseHeader_( std::string& to_parse ) {
 
 	std::cout << "HEADER: " << to_parse << std::endl;
 }
 
-void	Request::parseBody_( std::string to_parse ) {
+void	Request::parseBody_( std::string& to_parse ) {
 
 	std::cout << "BODY: " << to_parse << std::endl;
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -9,11 +9,6 @@ Request::Request( void )
 	/* default constructor */
 }
 
-// Request::Request( /*add parameters*/ ) {
-
-// 	/* parameterized constructor */
-// }
-
 Request::Request( const Request& to_copy ) {
 
 	*this = to_copy;


### PR DESCRIPTION
Adds a minimal request parser class that can be passed strings to the `add` method that are read from the sockets (but does not read the sockets). Currently process the input and prints to the standard out what has been sent to it.