### PR TITLE
Kan 7 response builder mvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 en.subject.pdf
 
+.vscode/
+
 /tests

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,12 @@ CYAN = \033[0;96m
 SRCS = \
 	main.cpp \
 	ResponseCodes.cpp \
-<<<<<<< HEAD
 	Response.cpp \
-=======
 	Request.cpp \
 	Logger.cpp			\
 	TimeUtils.cpp		\
 	Server.cpp			\
 	ft_stoi.cpp
->>>>>>> develop
 
 OBJS := $(SRCS:%.cpp=$(OBJ_DIR)%.o)
 DEPS = $(SRCS:%.cpp=$(OBJ_DIR)%.d)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ CYAN = \033[0;96m
 # Sources
 SRCS = \
 	main.cpp \
-	ResponseCodes.cpp
+	ResponseCodes.cpp \
+	Response.cpp \
 
 OBJS := $(SRCS:%.cpp=$(OBJ_DIR)%.o)
 DEPS = $(SRCS:%.cpp=$(OBJ_DIR)%.d)

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -6,6 +6,7 @@
 
 // class Request; //forward declaration for now
 
+
 /*! \brief Class for handling HTTP responses.
 *       
 *

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -4,8 +4,19 @@
 # include <string>
 # include "ResponseCodes.hpp"
 
-class Request;
+// class Request; //forward declaration for now
 
+/*! \brief Class for handling HTTP responses.
+*       
+*
+*  Response class handle HTTP responses. It is responsible for generating the response
+*  given a Request object.
+*  
+*  Methods:
+*  - generate: generate the response given a Request object
+*  - send: send the response to the client
+*  - clear: reset the response for next use
+*/
 class	Response {
 
 	private:
@@ -26,8 +37,8 @@ class	Response {
 
 		/* PUBLIC METHODS */
 
-		// void			generateResponse( Request& request );
-		std::string		send( /*socket to write to?*/ ) const;
+		// void			generate( Request& request );
+		const char*		get( /*socket to write to?*/ ) const;
 		void			clear( void ); /*reset for next use*/
 };
 

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -1,0 +1,34 @@
+#ifndef RESPONSE_HPP
+# define RESPONSE_HPP
+
+# include <string>
+# include "ResponseCodes.hpp"
+
+class Request;
+
+class	Response {
+
+	private:
+		/* PRIVATE METHODS AND MEMBERS */
+		std::string		response_;
+		std::string		body_;
+		int				status_code_;
+		// int				http_version_;
+		// int				content_length_;
+
+	public:
+		Response( void );
+		Response( const Response& to_copy );
+
+		~Response( void );
+
+		Response&	operator=( const Response& to_copy );
+
+		/* PUBLIC METHODS */
+
+		// void			generateResponse( Request& request );
+		std::string		send( /*socket to write to?*/ ) const;
+		void			clear( void ); /*reset for next use*/
+};
+
+#endif

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -3,12 +3,24 @@
 
 /* CONSTRUCTORS */
 
+/*! \brief Default constructor intializes empty response and body. Default status code set to 501 for MVP.
+*       
+*
+*  Default constructor intializes empty response and body. Default status code set to 501 for MVP.
+*  More details to be filled as project progresses.
+*/
 Response::Response( void )
-: response_(""), body(""), status_code_(501) {
+: response_(""), body_(""), status_code_(501) {
 
 	/* default constructor */
 }
 
+/*! \brief Copy constructor calls assignment operator.
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
 Response::Response( const Response& to_copy ) {
 
 	*this = to_copy;
@@ -16,6 +28,12 @@ Response::Response( const Response& to_copy ) {
 
 /* DESTRUCTOR */
 
+/*! \brief Default destructor has not special actions.
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
 Response::~Response( void ) {
 
 	/* destructor */
@@ -23,6 +41,12 @@ Response::~Response( void ) {
 
 /* OPERATOR OVERLOADS */
 
+/*! \brief Assignment operator copies all members from rhs to this.
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
 Response&	Response::operator=( const Response& rhs ) {
 
 	if (this != &rhs) {
@@ -35,22 +59,42 @@ Response&	Response::operator=( const Response& rhs ) {
 
 /* CLASS PUBLIC METHODS */
 
-// void	Response::generateResponse( Request& request ) {
+
+/*! \brief generate method creates the response given a Request object.
+*       
+*
+*  Not yet implemented.
+*  
+*/
+// void	Response::generate( Request& request ) {
 
 // 	/* generate response */
 // }
 
-std::string	Response::send( /*socket to write to?*/ ) const {
+/*! \brief get method returns the response as a c string.
+*       
+*
+*  Currently returns response from ResponseCodes class based on current status_code_.
+*  More details to be filled as project progresses.
+*  
+*/
+const char*	Response::get( /*socket to write to?*/ ) const {
 
-	return (ResponseCodes::getCombinedStatusLineAndBody(this->status_code_));
-	/* send response */
+	// return (ResponseCodes::getCombinedStatusLineAndBody(501).c_str());//default response for now
+	return (ResponseCodes::getCombinedStatusLineAndBody(this->status_code_).c_str());
 }
 
+/*! \brief clear method resets the response for next use
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
 void	Response::clear( void ) { 	/* reset for next use */
 
 	this->response_ = "";
 	this->body_ = "";
-	this->status_code_ = 501;
+	this->status_code_ = 0;
 }
 
 /* CLASS PRIVATE METHODS */

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,0 +1,56 @@
+
+#include "Response.hpp"
+
+/* CONSTRUCTORS */
+
+Response::Response( void )
+: response_(""), body(""), status_code_(501) {
+
+	/* default constructor */
+}
+
+Response::Response( const Response& to_copy ) {
+
+	*this = to_copy;
+} 
+
+/* DESTRUCTOR */
+
+Response::~Response( void ) {
+
+	/* destructor */
+} 
+
+/* OPERATOR OVERLOADS */
+
+Response&	Response::operator=( const Response& rhs ) {
+
+	if (this != &rhs) {
+
+		this->response_ = rhs.response_;
+		this->status_code_ = rhs.status_code_;
+	}
+	return (*this);
+}
+
+/* CLASS PUBLIC METHODS */
+
+// void	Response::generateResponse( Request& request ) {
+
+// 	/* generate response */
+// }
+
+std::string	Response::send( /*socket to write to?*/ ) const {
+
+	return (ResponseCodes::getCombinedStatusLineAndBody(this->status_code_));
+	/* send response */
+}
+
+void	Response::clear( void ) { 	/* reset for next use */
+
+	this->response_ = "";
+	this->body_ = "";
+	this->status_code_ = 501;
+}
+
+/* CLASS PRIVATE METHODS */


### PR DESCRIPTION
This Adds the minimal `Response` class with `get` and `clear` methods available. The default constructor initializes the error code to 501 => Not Implemented, if clear is called the error status will be 500 => Internal Server Error. The error responses are created using the `ResponseCodes`  class.