### PR TITLE
Kan 24 fix minimal response formatting

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -3,6 +3,13 @@
 
 # include <string>
 # include "ResponseCodes.hpp"
+# include "utility.hpp"
+#include <ctime>
+#include <time.h>
+
+# ifndef CRLF
+#  define CRLF "\r\n"
+# endif
 
 // class Request; //forward declaration for now
 
@@ -27,6 +34,7 @@ class	Response {
 		int				status_code_;
 		// int				http_version_;
 		// int				content_length_;
+		std::string		timeStampHeader( void ) const;
 
 	public:
 		Response( void );
@@ -39,7 +47,7 @@ class	Response {
 		/* PUBLIC METHODS */
 
 		// void			generate( Request& request );
-		const char*		get( /*socket to write to?*/ ) const;
+		const char*		get( /*socket to write to?*/ );
 		void			clear( void ); /*reset for next use*/
 };
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -78,11 +78,18 @@ Response&	Response::operator=( const Response& rhs ) {
 *  More details to be filled as project progresses.
 *  
 */
-const char*	Response::get( /*socket to write to?*/ ) const {
+const char*	Response::get( /*socket to write to?*/ ) {
 
-	// return (ResponseCodes::getCombinedStatusLineAndBody(501).c_str());//default response for now
-	// return (ResponseCodes::getCombinedStatusLineAndBody(this->status_code_).c_str());
-	return (ResponseCodes::getCodeStatusLine(this->status_code_).c_str());
+	std::string response;
+	
+	response = ResponseCodes::getCodeStatusLine(this->status_code_);
+	this->body_ = ResponseCodes::getCodeElementBody(this->status_code_);
+	response += this->timeStampHeader() + CRLF;
+	response += "Content-Length : ";
+	response += int_to_string(this->body_.length());
+	response += "\r\n\r\n";
+	response += this->body_ + CRLF + CRLF;
+	return (response.c_str());
 }
 
 /*! \brief clear method resets the response for next use
@@ -99,3 +106,17 @@ void	Response::clear( void ) { 	/* reset for next use */
 }
 
 /* CLASS PRIVATE METHODS */
+
+//check if logging time stamp can do the same thing
+std::string		Response::timeStampHeader( void ) const{
+
+	time_t	now = time(0);
+	struct tm tstruct;
+	std::string	time_stamp("Date: ");
+	char	buffer[100];
+
+	tstruct = *gmtime(&now);
+	strftime(buffer, sizeof(buffer), "%a, %d %b %Y %X GMT", &tstruct);
+	time_stamp += buffer;
+	return time_stamp;
+}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -221,7 +221,7 @@ void	ServerManager::sendResponseToClient( int client_fd ) {
 	if (response_string.empty())
 		return;
 
-	int	bytes_sent = send(client_fd, &response_string, response_string.length(), 0);
+	int	bytes_sent = send(client_fd, response_string.c_str(), response_string.length(), 0);
 	if (bytes_sent == -1) {
 		Logger::log(E_ERROR, COLOR_RED, "send error, from server %s to client %d",
 			this->client_map_[client_fd].getServer()->getServerIdforLog().c_str(), client_fd);


### PR DESCRIPTION
- Corrects server manger to send `response.c_str()` in `send()` call. 
- added time stamping function for Date header for response class
- added body and content length header for the hardcoded error codes.

State: Chrome recognizes the response as valid, can view the error code and headers in the dev-tool network function. HTML shows the error code and message correctly.