### PR TITLE
Kan 18 request parser 2 0

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -8,6 +8,7 @@
 
 // keep here?
 #include <sys/stat.h>
+# include "Color.hpp"
 
 enum	e_log_msg_type {
 	E_ERROR,

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -4,6 +4,9 @@
 # include <iostream>
 # include <sstream>
 # include <map>
+# include <vector>
+# include "utility.hpp"
+# include "Logger.hpp"
 
 # define CRLF "\r\n" //make this project wide?
 
@@ -11,25 +14,28 @@ class	Request {
 
 	private:
 		/* PRIVATE METHODS AND MEMBERS */
-		// things I think will be good to have a s a quick reference for the request handling
-		int									size_;
+		size_t								body_size_;
+		size_t								body_len_received_;					
 		bool 								chunked_;
 		bool								keep_alive_;
 		bool								headers_complete;
 		bool								complete_;
-		std::map<std::string, std::string>	request_line_; // method, uri, version
-		std::map<std::string, std::string>	headers_; //host, content-type, user-agent, content-egth, last-modified, PRAGMA, accept-encoding accept, connection, reffer, etc.
-		std::map<std::string, std::string>	body_; //body of the request, should it be a map?
+		bool								sever_error_;
+		std::map<std::string, std::string>	request_line_;
+		std::map<std::string, std::string>	headers_;
+		std::vector<std::string>			body_;
 		//no footers for now
 
 		void	parseRequestLine_( std::string& to_parse );
 		void	parseHeader_( std::string& to_parse );
 		void	parseBody_( std::string& to_parse );
-
-
+		void	setBodySize( void );
+		void	setChunked( void );
+		void	setKeepAlive( void );
+		void	setRequestAttributes( void );
 
 	public:
-		Request( void ); // itialize to default values
+		Request( void );
 		Request( const Request& to_copy );
 
 		~Request( void );
@@ -37,14 +43,26 @@ class	Request {
 		Request&	operator=( const Request& to_copy );
 
 		/* PUBLIC METHODS */
-		void	add( std::string to_add ); //add to any part of the response, will direct to correct private parsing function
-		void	clear( void ); //clear all data in the request
+		void	add( std::string to_add );
+		void	clear( void );
 
 		/* GETTERS */
-		int		getSize( void ) const;
-		bool	getChunked( void ) const;
-		bool	getKeepAlive( void ) const;
-		bool	getComplete( void ) const;
+		size_t		getBodySize( void ) const;
+		size_t		getBodyLengthReceived( void ) const;
+		bool		getChunked( void ) const;
+		bool		getKeepAlive( void ) const;
+		bool		getComplete( void ) const;
+		bool		getServerError( void ) const;
+
+		void		printRequest( void ) const;
+
+		std::string											getRequestLineValue( std::string& key ) const;
+		std::map<std::string, std::string>::const_iterator	getHeaderBegin( void ) const;
+		std::map<std::string, std::string>::const_iterator	getHeaderEnd( void ) const;
+		std::string											getHeaderValueByKey( std::string& key ) const;
+		std::vector<std::string>::iterator	getBodyBegin( void );
+		std::vector<std::string>::iterator	getBodyEnd( void );
+		// const std::string&	getBody() const;
 };
 
 #endif

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -4,7 +4,7 @@
 /* CONSTRUCTORS */
 
 Request::Request( void ) 
-: size_(0), chunked_(false), keep_alive_(false), headers_complete(false), complete_(false) {
+: body_size_(0), body_len_received_(0), chunked_(false), keep_alive_(false), headers_complete(false), complete_(false), sever_error_(false) {
 
 	/* default constructor */
 }
@@ -26,7 +26,8 @@ Request::~Request( void ) {
 Request&	Request::operator=( const Request& rhs ) {
 
 	if (this != &rhs ) {
-		this->size_ = rhs.size_;
+		this->body_size_ = rhs.body_size_;
+		this->body_len_received_ = rhs.body_len_received_;
 		this->chunked_ = rhs.chunked_;
 		this->keep_alive_ = rhs.keep_alive_;
 		this->request_line_ = rhs.request_line_;
@@ -37,59 +38,61 @@ Request&	Request::operator=( const Request& rhs ) {
 	return (*this);
 }
 
-/* CLASS PUBLIC METHODS */
+/************** CLASS PUBLIC METHODS **************/
 
-/* EXAMPLES */
-/* Request */
-// Get /mysite/index.html HTTP/1.1\r\n
-// Host: 10.101.101.10\r\n
-// Accept: */*\r\n
-// \r\n
-
-/* Response */
-// HTTP/1.1 200 OK\r\n
-// Content-Length: 55\r\n
-// Content-Type: text/html\r\n
-// Last-Modified: Wed, 12 Aug 1998 15:03:50 GMT\r\n
-// Accept-Ranges: bytes\r\n
-// ETag: “04f97692cbd1:377”\r\n
-// Date: Thu, 19 Jun 2008 19:29:07 GMT\r\n
-// \r\n
-// <55-character response>
-
-void	Request::add( std::string to_add ) { //add to any part of the Request, will direct to correct private parsing function
+/*! \brief add to any part of the Request, directs to correct private parsing function
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
+void	Request::add( std::string to_add ) {
 	
 	std::stringstream	ss(to_add);
 	std::string			line;
 
-	while (getline(ss, line, '\n')) { // do I need my own getline??
-		line += "\n";
-		if (this->request_line_.empty()) {
-			this->parseRequestLine_(line);
-		}
-		else if (this->headers_complete == false) {
-			if (line.compare(CRLF) == 0) {
-				this->headers_complete = true;
-				continue ;
+	try {
+		while (getline(ss, line, '\n')) { // do I need my own getline??
+			if (this->request_line_.empty()) {
+				this->parseRequestLine_(line);
+			}
+			else if (this->headers_complete == false) {
+				if (line.compare("\r") == 0) {
+					this->headers_complete = true;
+					continue ;
+				}
+				else {
+					this->parseHeader_(line);
+				}
+			}
+			else if (this->headers_complete && line.compare("\r") == 0) {
+				break ;
 			}
 			else {
-				this->parseHeader_(line);
+				this->parseBody_(line);
 			}
 		}
-		else if (this->headers_complete && line.compare(CRLF) == 0) {
-			break ;
-		}
-		else {
-			this->parseBody_(line);
+		this->setRequestAttributes();
+		if (this->headers_complete && this->body_size_ == this->body_len_received_) {
+			this->complete_ = true;
 		}
 	}
-	std::cout << "Parsing complete!!!!" << std::endl;//
-	this->complete_ = true;
+	catch (const std::exception& e) {
+		Logger::log(E_ERROR, COLOR_RED, e.what());
+		this->sever_error_ = true;
+	}
 }
 
-void	Request::clear( void ) { //clear all data in the request
+/*! \brief clears all containers and resets all values to intial state
+*       
+*
+*  More details to be filled as project progresses.
+*  
+*/
+void	Request::clear( void ) {
 
-	this->size_ = 0;
+	this->body_size_ = 0;
+	this->body_len_received_ = 0;
 	this->chunked_ = false;
 	this->keep_alive_ = false;
 	this->headers_complete = false;
@@ -97,30 +100,193 @@ void	Request::clear( void ) { //clear all data in the request
 	this->headers_.clear();
 	this->body_.clear();
 	this->complete_ = false;
+	this->sever_error_ = false;
 }
 
-/* CLASS PRIVATE METHODS */
+/*! \brief prints to standard output `REQUEST` followed by
+*				each request element on a newline.
+*
+*  More details to be filled as project progresses.
+*  
+*/
+void	Request::printRequest( void ) const {
 
-void	Request::parseRequestLine_( std::string& to_parse ) {
-
-	std::cout << "REQUEST LINE: " << to_parse << std::endl;
-	this->request_line_["test"] = to_parse;
+	std::cout << "REQUEST: " << std::endl;
+	for (std::map<std::string, std::string>::const_iterator it = this->request_line_.begin(); it != this->request_line_.end(); it++) {
+		std::cout << it->first << ": " << it->second << std::endl;
+	}
+	for (std::map<std::string, std::string>::const_iterator it = this->headers_.begin(); it != this->headers_.end(); it++) {
+		std::cout << it->first << ": " << it->second << std::endl;
+	}
+	for (std::vector<std::string>::const_iterator it = this->body_.begin(); it != this->body_.end(); it++) {
+		std::cout << *it;;
+	}
+	if (!this->body_.empty())
+		std::cout << std::endl;
 }
 
-//save specific values for easy access
+/************** PUBLIC GETTERS **************/
 
-void	Request::parseHeader_( std::string& to_parse ) {
-
-	std::cout << "HEADER: " << to_parse << std::endl;
+size_t		Request::getBodySize( void ) const {
+	
+	return (this->body_size_);
 }
 
-void	Request::parseBody_( std::string& to_parse ) {
+size_t		Request::getBodyLengthReceived( void ) const {
 
-	std::cout << "BODY: " << to_parse << std::endl;
+	return (this->body_len_received_);
+}
+
+bool	Request::getChunked( void ) const {
+
+	return (this->chunked_);
+}
+
+bool	Request::getKeepAlive( void ) const {
+
+	return (this->keep_alive_);
 }
 
 
 bool	Request::getComplete( void ) const {
 
 	return (this->complete_);
+}
+
+bool	Request::getServerError( void ) const {
+	
+	return (this->sever_error_);
+}
+
+std::string	Request::getRequestLineValue( std::string& key ) const {
+
+	std::map<std::string, std::string>::const_iterator value = this->request_line_.find(key);
+	if (value ==  this->request_line_.end()) {
+		return ("");
+	}
+	else {
+		return (value->second);
+	}
+}
+
+std::map<std::string, std::string>::const_iterator	Request::getHeaderBegin( void ) const {
+
+	return (this->headers_.begin());
+}
+
+
+std::map<std::string, std::string>::const_iterator	Request::getHeaderEnd( void ) const {
+
+	return (this->headers_.end());
+}
+
+std::string	Request::getHeaderValueByKey( std::string& key ) const {
+
+	std::map<std::string, std::string>::const_iterator value = this->headers_.find(key);
+	if (value ==  this->headers_.end()) {
+		return ("");
+	}
+	else {
+		return (value->second);
+	}
+}
+
+std::vector<std::string>::iterator	Request::getBodyBegin( void ) {
+
+	return (this->body_.begin());
+}
+
+std::vector<std::string>::iterator	Request::getBodyEnd( void ) {
+	
+	return (this->body_.end());
+}
+
+/************** CLASS PRIVATE METHODS **************/
+
+/************** PRIVATE SETTERS **************/
+
+
+void	Request::setBodySize( void ) {
+
+	std::string	content_length = this->headers_["Content-Length"];
+	this->body_size_ = ft_stoi(content_length);
+}
+
+void	Request::setChunked( void ) {
+
+	std::string	transfer_encoding = this->headers_["Transfer-Encoding"];
+	if (transfer_encoding == "chunked") {
+		this->chunked_ = true;
+	}
+	else {
+		this->chunked_ = false;
+	}
+}
+
+void	Request::setKeepAlive( void ) {
+
+	std::string connection = this->headers_["Connection"];
+	if (connection == "keep-alive") {
+		this->keep_alive_ = true;
+	}
+	else {
+		this->keep_alive_ = false;
+	}
+}
+
+void	Request::setRequestAttributes( void ) {
+
+	void	(Request::*setters[])(void) = { &Request::setKeepAlive, &Request::setChunked, &Request::setBodySize };
+	for (int i = 0; i < 3; i++) { //get size of setters instead of 3
+		(this->*setters[i])();
+	}
+}
+
+void	Request::parseRequestLine_( std::string& to_parse ) {
+
+	std::stringstream	ss(to_parse);
+	std::string			part;
+
+	if (ss.fail() || ss.bad()) {
+		throw(std::runtime_error("Stringstream failed in parseRequestLine_"));
+	}
+	ss >> part;
+	this->request_line_["method"] = part;
+	ss >> part;
+	this->request_line_["uri"] = part;
+	ss >> part;
+	this->request_line_["version"] = part;
+
+}
+
+/*! \brief parses key and value from request header.
+*       
+*
+*  If a header already exists it will not overwrite the old value.
+*  
+*/
+void	Request::parseHeader_( std::string& to_parse ) {
+
+	std::stringstream	ss(to_parse);
+	std::string			key;
+	std::string			value;
+	size_t				key_len;
+
+	if (ss.fail() || ss.bad()) {
+		throw(std::runtime_error("Stringstream failed in parseHeader_"));
+	}
+	getline(ss, key, ':');
+	key_len = key.length();
+	value = to_parse.substr(key_len + 2, to_parse.length() - key_len);
+	value.pop_back();
+	if (this->headers_[key].empty()) {
+		this->headers_[key] = value;
+	}
+}
+
+void	Request::parseBody_( std::string& to_parse ) {
+
+	to_parse.pop_back();
+	this->body_.push_back(to_parse);
+	this->body_len_received_ += to_parse.length();
 }


### PR DESCRIPTION
add parsing into containers of request elements, make getter and setters for the body size, chunked status, keep-alive status, server error. Also added print request public method for test purposes. Other getters added in anticipation of potential uses in making response. Local tests passed.

Reviewed attributes and getters with Sakari to make sure they will meet his current known needs for the socket handling and error printing.