### PR TITLE
KAN-18  pass string literals as keys

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -56,10 +56,10 @@ class	Request {
 
 		void		printRequest( void ) const;
 
-		std::string											getRequestLineValue( std::string& key ) const;
+		std::string											getRequestLineValue( std::string key ) const;
 		std::map<std::string, std::string>::const_iterator	getHeaderBegin( void ) const;
 		std::map<std::string, std::string>::const_iterator	getHeaderEnd( void ) const;
-		std::string											getHeaderValueByKey( std::string& key ) const;
+		std::string											getHeaderValueByKey( std::string key ) const;
 		std::vector<std::string>::iterator	getBodyBegin( void );
 		std::vector<std::string>::iterator	getBodyEnd( void );
 		// const std::string&	getBody() const;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -158,7 +158,7 @@ bool	Request::getServerError( void ) const {
 	return (this->sever_error_);
 }
 
-std::string	Request::getRequestLineValue( std::string& key ) const {
+std::string	Request::getRequestLineValue( std::string key ) const {
 
 	std::map<std::string, std::string>::const_iterator value = this->request_line_.find(key);
 	if (value ==  this->request_line_.end()) {
@@ -180,7 +180,7 @@ std::map<std::string, std::string>::const_iterator	Request::getHeaderEnd( void )
 	return (this->headers_.end());
 }
 
-std::string	Request::getHeaderValueByKey( std::string& key ) const {
+std::string	Request::getHeaderValueByKey( std::string key ) const {
 
 	std::map<std::string, std::string>::const_iterator value = this->headers_.find(key);
 	if (value ==  this->headers_.end()) {


### PR DESCRIPTION
It is my shame that I left a change in that was added while adding the log printing and forgot to remove it. It is the intention that the getters for the maps int he class can be searched with a string literal and therefore cannot accept references to strings. If we change the searching methods in the future we can readdress this.