### PR TITLE
add to Validator class catcher to reject config files with missing re…

### DIFF
--- a/config/bad/missingkeys.conf
+++ b/config/bad/missingkeys.conf
@@ -1,0 +1,114 @@
+server
+{
+    main
+    {
+        server_name localhost;
+        host 127.0.0.1;
+        root ./resources;
+        client_max_body_size 3000;
+        index index.html;
+        error_page_404 ./www/html/error404/error.html;
+        error_page_405 ./www/html/error405/error.html;
+        error_page_500 ./www/html/error500/error.html;
+    }
+
+    location /board
+    {
+		allow_methods GET;
+		root ./www/html;
+	}
+
+    location /board/content 
+    {
+		allow_methods GET POST DELETE;
+		root ./www/html/contents;
+		index board.html;
+		cgi_ext .php php-cgi;
+	}
+
+    location /
+    {
+        allow_methods  DELETE POST GET;
+        client_body_limit 100;
+        autoindex off;
+    }
+
+    location /tours
+    {
+        autoindex on;
+        index tours1.html;
+        allow_methods GET POST PUT HEAD;
+    }
+
+    location /img
+    {
+        index img.jpg;
+        allow_methods GET POST PUT HEAD;
+    }
+
+	location /red
+    {
+		return /tours;
+	}
+
+    location /blue
+    {
+		alias green.html;
+	}
+    
+    location /cgi-bin
+    {
+        root ./;
+        allow_methods GET POST DELETE;
+        index time.py;
+        cgi_path /usr/bin/python3 /bin/bash;
+        cgi_ext .py .sh;
+    }
+}
+
+server
+{
+    main
+    {
+        listen 8080;
+        server_name localhost;
+        host 127.0.0.1;
+        root docs/fusion_web/;
+        client_max_body_size 3000000;
+        index index.html;
+        error_page_404 ./www/html/error404/error.html;
+        error_page_405 ./www/html/error405/error.html;
+        error_page_500 ./www/html/error500/error.html;
+    }
+
+    location /
+    {
+        allow_methods GET;
+    } 
+
+    location /tours
+    {
+        autoindex on;
+        index tours1.html;
+        allow_methods GET POST PUT HEAD;
+    }
+
+	location /red
+    {
+		alias /tours;
+	}
+
+    location /blue
+    {
+		return green.html;
+	}
+    
+    location /cgi-bin
+    {
+        root ./;
+        allow_methods GET POST DELETE;
+        index time.py;
+        cgi_path /usr/bin/python3 /bin/bash;
+        cgi_ext .py .sh;
+    }
+}

--- a/config/bad/noPermission.conf
+++ b/config/bad/noPermission.conf
@@ -1,0 +1,67 @@
+server
+{
+    main
+    {
+		listen 8010;
+        server_name localhost;
+        host 127.0.0.1;
+        root ./resources;
+        client_max_body_size 3000;
+        index index.html;
+        error_page_404 ./www/html/error404/error.html;
+        error_page_405 ./www/html/error405/error.html;
+        error_page_500 ./www/html/error500/error.html;
+    }
+
+    location /board
+    {
+		allow_methods GET;
+		root ./www/html;
+	}
+
+    location /board/content 
+    {
+		allow_methods GET POST DELETE;
+		root ./www/html/contents;
+		index board.html;
+	}
+
+    location /
+    {
+        allow_methods  DELETE POST GET;
+        client_body_limit 100;
+        autoindex off;
+    }
+
+    location /tours
+    {
+        autoindex on;
+        index tours1.html;
+        allow_methods GET POST PUT HEAD;
+    }
+
+    location /img
+    {
+        index img.jpg;
+        allow_methods GET POST PUT HEAD;
+    }
+
+	location /red
+    {
+		return /tours;
+	}
+
+    location /blue
+    {
+		alias green.html;
+	}
+    
+    location /cgi-bin
+    {
+        root ./;
+        allow_methods GET POST DELETE;
+        index time.py;
+        cgi_path /usr/bin/python3 /bin/bash;
+        cgi_ext .py .sh;
+    }
+}

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -61,6 +61,10 @@ public:
 	const std::vector<std::string>*	getLocationValue( std::string locationBlockKey, std::string key ) const;
 	bool							isKeyInLocation( std::string locationBlockKey, std::string key ) const;
 	bool							isLocationInServer( std::string locationBlockKey ) const;
+	bool							isValueListedForKey( std::string locationBlockKey, std::string key, std::string value ) const;
+	bool							isExtentionOnCgiList( std::string extention ) const;
+	bool							isScriptOnCgiList( std::string script ) const;
+
 };
 
 #endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -318,3 +318,25 @@ bool	Server::isLocationInServer( std::string locationBlockKey ) const{
 	}
 	return false;
 }
+
+bool	Server::isValueListedForKey( std::string locationBlockKey, std::string key, std::string value ) const{
+
+	const std::vector<std::string>*	values = this->getLocationValue(locationBlockKey, key);
+		
+		if (!values || values->empty())
+			return (false);
+		else if (std::find(values->begin(), values->end(), value) == values->end())
+			return (false);
+		else
+			return (true);
+}
+
+bool	Server::isExtentionOnCgiList( std::string extention ) const{
+
+	return (isValueListedForKey("/cgi-bin", "cgi_ext", extention));
+}
+
+bool	Server::isScriptOnCgiList( std::string script ) const{
+
+	return (isValueListedForKey("/cgi-bin", "index", script));
+}

--- a/srcs/Validator.cpp
+++ b/srcs/Validator.cpp
@@ -380,7 +380,7 @@ bool Validator::checkMainBlockKeyValues(void){
 	// 		std::cout << *it << std::endl;
 	// 	}
 	// }
-
+	std::vector<int> keys;
 	for (std::map<std::string, std::vector<std::string> >::iterator outerIt = innerBlock.begin(); outerIt != innerBlock.end(); outerIt++){
 		//std::cout << "key : " << outerIt->first << std::endl;
 		//std::cout << "value : " << outerIt->second[0] << std::endl;
@@ -391,6 +391,7 @@ bool Validator::checkMainBlockKeyValues(void){
 			Logger::log(E_ERROR, COLOR_RED, "%s is not a valid key.", (*outerIt).first.c_str());
 			return false;
 		}
+		keys.push_back(i);
 		if ( outerIt->second.size() > 1 ){
 			Logger::log(E_ERROR, COLOR_RED, "%s can not have more than one value.", (outerIt->first).c_str());
 			return false;
@@ -403,6 +404,13 @@ bool Validator::checkMainBlockKeyValues(void){
 				return false;
 			}
 		}
+	}
+	for (int i = 0; i < 9; i++){
+		if (std::find(keys.begin(), keys.end(), i) == keys.end()){
+			Logger::log(E_ERROR, COLOR_RED, "%s is a required key.", valid_main_keys[i].c_str());
+			return false;
+		}
+
 	}
 	return true;
 }


### PR DESCRIPTION
This pull request adds to Validator class catcher to reject config files with missing required values. Add 3 methods to Server class to return bool to verify if a key is present in a location for a certain key, if cgi extension is listed for cgi block, if a script is listed for cgi block