### PR TITLE
KAN-65-refactoring-of-ServerManager-add-client-timeout-feature

### DIFF
--- a/config/good/default_macbook.conf
+++ b/config/good/default_macbook.conf
@@ -1,12 +1,12 @@
 # this is a config file for macbooks where cgi python3 path is different
 server
 {
-    main#coment is alos allowed here
+    main
     {
 		listen 8080;
         server_name localhost;
-        host 127.0.0.1;#coment is alos allowed here
-        root ./resources;
+        host 127.0.0.1;
+        root ./website;
         client_max_body_size 900000;
         index index.html;
         error_page_404 /errors/404.html;
@@ -16,71 +16,56 @@ server
 
     location /
     {
-        allow_methods DELETE POST GET;
+        allow_methods GET HEAD;
         client_body_size 900007;
         autoindex off;
     }
 
-    location /test_location
+    location /dog
     {
-		allow_methods GET;
-		root ./resources/test;
-        # index ./www/html/index.html;
+		allow_methods GET POST DELETE HEAD;
+        index dogs.html;
 	}
 
-    location /test/test
+    location /cat
     {
-		allow_methods GET POST DELETE;
-		#root ./resources/test/test;
-		index test.html;
+		allow_methods GET POST DELETE HEAD;
+		index cats.html;
 	}
 
-	location /red
+	location /add_post
     {
-		return /test_location;
+		allow_methods GET POST HEAD;
+		index form.html;
 	}
 
-    location /tours
+    location /pet
     {
-        autoindex on;
-        root ./resources/test/test;
-        index test.html;
-        allow_methods GET POST HEAD;
+        return /dog;
     }
 
-    location /img
+	location /pishoo
     {
-        root ./resources/test;
-        index img.jpg;
-        allow_methods GET POST HEAD;
+        alias /cat;
     }
-
-
-    location /test/blue_yellow45/*8
-    {
-		alias /test_location;
-        allow_methods GET POST HEAD;
-	}
     
     location /cgi-bin
     {
-        root ./;
         allow_methods GET POST DELETE;
-        index test.sh config_tester.py;
-		cgi_path /usr/bin/python3 /bin/bash;
+        script add_post.py delete_post.sh;
+        cgi_path /usr/bin/python3 /bin/bash;
         cgi_ext .py .sh;
     }
 }
 
-#coment is allowed here
 server
 {
-    main#coment is alos allowed here
+    main
     {
 		listen 9090;
         server_name localhost;
-        host 127.0.0.1;#coment is alos allowed here
-        root ./resources;
+        host 127.0.0.1;
+        root ./website;
         client_max_body_size 900000;
         index index.html;
         error_page_404 /errors/404.html;
@@ -90,57 +75,102 @@ server
 
     location /
     {
-        allow_methods DELETE POST GET;
+        allow_methods GET HEAD;
         client_body_size 900007;
         autoindex off;
     }
 
-    location /test_location
+    location /dog
     {
-		allow_methods GET;
-		root ./resources/test;
-        # index ./www/html/index.html;
+		allow_methods GET HEAD;
+        index dogs.html;
 	}
 
-    location /test/test
+    location /cat
     {
-		allow_methods GET POST DELETE;
-		#root ./resources/test/test;
-		index test.html;
+		allow_methods GET HEAD;
+		index cats.html;
 	}
 
-	location /red
+	location /add_post
     {
-		return /test_location;
+		allow_methods GET HEAD;
+		index form.html;
 	}
 
-    location /tours
+    location /labrador
     {
-        autoindex on;
-        root ./resources/test/test;
-        index test.html;
-        allow_methods GET POST HEAD;
+        return /dog;
     }
 
-    location /img
+	location /Persiancat
     {
-        root ./resources/test;
-        index img.jpg;
-        allow_methods GET POST HEAD;
+        alias /cat;
     }
-
-
-    location /test/blue_yellow45/*8
-    {
-		alias /test_location;
-        allow_methods GET POST HEAD;
-	}
     
     location /cgi-bin
     {
-        root ./;
         allow_methods GET POST DELETE;
-        index test.sh config_tester.py;
+        script add_post.py delete_post.sh;
+        cgi_path /usr/bin/python3 /bin/bash;
+        cgi_ext .py .sh;
+    }
+}
+
+server
+{
+    main
+    {
+		listen 8000;
+        server_name localhost;
+        host 127.0.0.1;
+        root ./website;
+        client_max_body_size 900000;
+        index index.html;
+        error_page_404 /errors/404.html;
+        error_page_405 /errors/405.html;
+        error_page_500 /errors/500.html;
+    }
+
+    location /
+    {
+        allow_methods GET HEAD;
+        client_body_size 900007;
+        autoindex off;
+    }
+
+    location /dog
+    {
+		allow_methods GET POST HEAD;
+        index dogs.html;
+	}
+
+    location /cat
+    {
+		allow_methods GET POST HEAD;
+		index cats.html;
+	}
+
+	location /add_post
+    {
+		allow_methods GET POST HEAD;
+		index form.html;
+	}
+
+    location /musti
+    {
+        return /dog;
+    }
+
+	location /miri
+    {
+        alias /cat;
+    }
+    
+    location /cgi-bin
+    {
+        allow_methods GET POST DELETE;
+        script add_post.py delete_post.sh;
         cgi_path /usr/bin/python3 /bin/bash;
         cgi_ext .py .sh;
     }

--- a/include/CgiHandler.hpp
+++ b/include/CgiHandler.hpp
@@ -2,6 +2,7 @@
 # define CGIHANDLER_HPP
 
 # include "Client.hpp"
+# include "WebServ.hpp"
 
 # include <unistd.h>
 # include <fcntl.h>
@@ -12,12 +13,6 @@
 
 // forward declaration
 class Client;
-
-// macro for cgi timeout
-# define CGI_TIMEOUT 5
-
-// macro for buffer for cgi output reading
-# define CGI_OUTPUT_BUFFER 102400
 
 enum	e_cgi_results {
 	E_CGI_OK,

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -5,20 +5,6 @@
 # include "Server.hpp"
 # include "Client.hpp"
 
-// for timing out select()
-# define SELECT_TIMEOUT_SEC 2
-# define SELECT_TIMEOUT_USEC 0
-
-// for timing out poll()
-# define POLL_TIMEOUT_MILLISEC 2 * 1000
-
-// time the servers will run for without any client action (in seconds)
-# define	SERVER_SHUTDOWN_TIME_SEC 7 * 60
-
-
-// time a client connection is kept open from last client action (in seconds)
-# define	CLIENT_TIMEOUT_SEC 1 * 60
-
 /*! \brief Server Manager class.
 *         This class handles managing the server and client sockets.
 *
@@ -66,7 +52,7 @@ class	ServerManager {
 		void	closeServerSockets( void );
 		void	closeAllClientConnections( void );
 		void	closeAllSockets( void );
-		bool	checkLastClientTime( void );
+		bool	CheckServersTimeout( void );
 		void	removeClient( int client_fd );
 		bool	receiveFromClient( int client_fd );
 		bool	sendResponseToClient( int client_fd );

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -14,10 +14,15 @@
 // time the servers will run for without any client action (in seconds)
 # define	SERVER_SHUTDOWN_TIME_SEC 7 * 60
 
+<<<<<<< Updated upstream
 // this macro is used to switch the webserver version between one that uses poll and one that uses select
 # ifndef POLL_TRUE_SELECT_FALSE
 #  define POLL_TRUE_SELECT_FALSE true
 # endif
+=======
+// time a client connection is kept open from last client action (in seconds)
+# define	CLIENT_TIMEOUT_SEC 1 * 60
+>>>>>>> Stashed changes
 
 /*! \brief Server Manager class.
 *         This class handles managing the server and client sockets.
@@ -64,13 +69,14 @@ class	ServerManager {
 		ServerManager&	operator=( const ServerManager& rhs );
 
 		void	closeServerSockets( void );
-		void	closeClientSockets( void );
+		void	closeAllClientConnections( void );
 		void	closeAllSockets( void );
 		bool	checkLastClientTime( void );
 		void	removeClient( int client_fd );
 		bool	receiveFromClient( int client_fd );
 		bool	sendResponseToClient( int client_fd );
 		int		getClientFdByItsCgiPipeFd( int pipe_fd );
+		void	checkIfClientTimeout( int client_fd );
 
 
 		bool	SELECT_initializeServers( void );

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -31,7 +31,7 @@
 // MACRO FOR SWITCHING BETWEEN HIVE COMPUTERS AND MACBOOKS (REMOVE LATER?)
 // (switch between desktop version (default.conf and logger uses vsprintf) and macbook version (default_macbook.conf and logger uses vsnprintf))
 # ifndef HIVE_DESKTOP_OR_MACBOOK
-#  define HIVE_DESKTOP_OR_MACBOOK false
+#  define HIVE_DESKTOP_OR_MACBOOK true
 # endif
 
 

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -1,3 +1,12 @@
+/*  
+    THIS HPP FILE IS FOR ALMOST ALL MACROS IN THE PROJECT
+    THIS IS VERY USEFUL: IF YOU WANT TO CHANGE SOMETHING, YOU CAN JUST EDIT THIS FILE!
+
+    THE FIRST PART ARE BOOL MACROS WHERE YOU CAN ENABLED CERTAIN FEATURES OR NOT
+    THE SECOND PART CONTAINS TIME SETTINGS FOR THE SERVERMANAGER
+    THE THIRD PART CONTAINS TIME SETTINGS FOR CGI
+*/
+
 #ifndef	WEBSERV_HPP
 # define WEBSERV_HPP
 
@@ -8,13 +17,46 @@
 
 // MACRO FOR GETTING MORE DEBUG LOG (MORE INFO)
 # ifndef GET_DEBUG_LOG
-#  define GET_DEBUG_LOG	false
+#  define GET_DEBUG_LOG	true
+# endif
+
+// NEW MACRO FOR ENABLING/DISABLING GETTING FD INFO FOR SELECT/POLL LOOP
+// (they flood the terminal/logs, but useful in some cases)
+# if GET_DEBUG_LOG
+#  ifndef GET_SELECT_POLL_LOOP_FD_INFO
+#   define GET_SELECT_POLL_LOOP_FD_INFO false
+#  endif
 # endif
 
 // MACRO FOR SWITCHING BETWEEN HIVE COMPUTERS AND MACBOOKS (REMOVE LATER?)
 // (switch between desktop version (default.conf and logger uses vsprintf) and macbook version (default_macbook.conf and logger uses vsnprintf))
 # ifndef HIVE_DESKTOP_OR_MACBOOK
-#  define HIVE_DESKTOP_OR_MACBOOK true
+#  define HIVE_DESKTOP_OR_MACBOOK false
 # endif
+
+
+/*********************************************** ServerManager macros ***********************************************/
+
+// for timing out select()
+# define SELECT_TIMEOUT_SEC 2
+# define SELECT_TIMEOUT_USEC 0
+
+// for timing out poll()
+# define POLL_TIMEOUT_MILLISEC 2 * 1000
+
+// time the servers will run for without any client action (in seconds)
+# define SERVER_SHUTDOWN_TIME_SEC 5 * 60
+
+// time a client connection is kept open from last client action (in seconds)
+# define CLIENT_TIMEOUT_SEC 1 * 10
+
+
+/*********************************************** CGI macros ***********************************************/
+
+// macro for cgi timeout
+# define CGI_TIMEOUT 5
+
+// macro for buffer for cgi output reading
+# define CGI_OUTPUT_BUFFER 102400
 
 #endif

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -33,6 +33,7 @@ CgiHandler::CgiHandler( const CgiHandler& to_copy )
 
 CgiHandler::~CgiHandler( void ) {
 
+	this->closeCgiPipes();
 	deleteAllocatedCStringArray(this->metavariables_);
 	deleteAllocatedCStringArray(this->args_);
 	if (this->path_ != NULL)

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -9,7 +9,8 @@ Client::Client( void ) : response_(NULL), cgi_handler_(NULL) {
 
 	this->fd_ = -1;
 	memset(&this->address_, 0, sizeof(this->address_));
-	this->latest_time_ = time(0);
+	// this->latest_time_ = time(0);
+	time(&this->latest_time_);
 
 	this->resetRequest();
 	this->resetResponse();
@@ -28,7 +29,8 @@ Client::Client( int server_fd, Server* server ) : response_(server), cgi_handler
 
 	this->fd_ = -1;
 	memset(&this->address_, 0, sizeof(this->address_));
-	this->latest_time_ = time(0);
+	// this->latest_time_ = time(0);
+	time(&this->latest_time_);
 
 	this->resetRequest();
 	this->resetResponse();
@@ -136,6 +138,7 @@ bool	Client::startCgiResponse( void ) {
 
 void	Client::finishCgiResponse( void ) {
 
+	this->setLatestTime();
 	int	result = this->cgi_handler_->cgiFinish(this->response_);
 	std::string method = this->request_.getRequestLineValue("method");
 
@@ -161,7 +164,8 @@ void	Client::finishCgiResponse( void ) {
 // setters
 void	Client::setLatestTime( void ) {
 	
-	this->latest_time_ = time(0);
+	// this->latest_time_ = time(0);
+	time(&this->latest_time_);
 }
 
 // getters

--- a/srcs/Logger.cpp
+++ b/srcs/Logger.cpp
@@ -53,7 +53,7 @@ void	Logger::log( int msg_type, const char *msg_color, const char *msg, ... ) {
 	char	buffer[1024];
 
 	// hive desktops allow deprecated vsprintf (which is also needed because vsnprintf is c++11)
-	#ifdef HIVE_DESKTOP_OR_MACBOOK
+	#if HIVE_DESKTOP_OR_MACBOOK
 		vsprintf(buffer, msg, args); //change back for shcool computers
 	#else
 		vsnprintf(buffer, 1024, msg, args); //change back for shcool computers

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -145,7 +145,7 @@ bool	ServerManager::CheckServersTimeout( void ) {
 
 void	ServerManager::removeClient( int client_fd ) {
 
-	Logger::log(E_INFO, COLOR_MAGENTA, "Closing socket %d connection, clearing client data...", client_fd);
+	Logger::log(E_INFO, COLOR_MAGENTA, "Closing socket %d, clearing client data...", client_fd);
 	close(client_fd);
 	this->client_map_.erase(client_fd);
 }
@@ -169,7 +169,7 @@ bool	ServerManager::receiveFromClient( int client_fd ) {
 		Logger::log(E_ERROR, COLOR_RED, "recv error, from socket %d to server %s",
 			client_fd, server->getServerIdforLog().c_str());
 	else if (bytes_received == 0){ // client has disconnected...
-		Logger::log(E_INFO, COLOR_WHITE, "Client %d has disconnected", client_fd);
+		Logger::log(E_INFO, COLOR_MAGENTA, "Client %d has disconnected", client_fd);
 		return false;
 	} else {
 		client->addToRequest(client_msg);

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -45,7 +45,7 @@ int  main( int argc, char *argv[]) {
   #if POLL_TRUE_SELECT_FALSE
     // POLL VERSION
     while (true) {
-      ServerManager server_manager(server_vector);
+      ServerManager server_manager(Validator::servers);
       if (!server_manager.POLL_initializeServers()) {  
         server_manager.closeServerSockets();
         Logger::closeLogFiles();
@@ -58,7 +58,7 @@ int  main( int argc, char *argv[]) {
   #else
   //SELECT VERSION
     while (true) {
-      ServerManager server_manager(server_vector);
+      ServerManager server_manager(Validator::servers);
       if (!server_manager.SELECT_initializeServers()) {  
         server_manager.closeServerSockets();
         Logger::closeLogFiles();

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -23,7 +23,7 @@ int  main( int argc, char *argv[]) {
     return 1;
   }
   else if (argc == 1){
-    #ifdef HIVE_DESKTOP_OR_MACBOOK
+    #if HIVE_DESKTOP_OR_MACBOOK
     if (!Validator::validate("config/good/default.conf")){
         Logger::log(E_INFO, COLOR_RED, "Default config is not valid!");
         Logger::closeLogFiles();


### PR DESCRIPTION
This pull request adds timing out of clients, which wasn't implemented before.

There is some other general refactoring going on here as well when it comes to the ServerManager.
Some log statements have been modified or added to make the connecting or disconnecting clearer.
I added a new macro that is by default disabled which controls the printing of the fds in every poll/select loop.
I have moved more macros to the WebServ.hpp so that we can control every value (like client or server timeout) from that file.