### PR TITLE
KAN-43 add fucntion to create error body for response, fixed storage …

### DIFF
--- a/config/good/default.conf
+++ b/config/good/default.conf
@@ -8,9 +8,9 @@ server
         root ./website;
         client_max_body_size 900000;
         index index.html;
-        error_page_404 /errors/404.html;
-        error_page_405 /errors/405.html;
-        error_page_500 /errors/500.html;
+        error_page_404 errors/404.html;
+        error_page_405 errors/405.html;
+        error_page_500 errors/500.html;
     }
 
     location /
@@ -67,9 +67,9 @@ server
         root ./website;
         client_max_body_size 900000;
         index index.html;
-        error_page_404 /errors/404.html;
-        error_page_405 /errors/405.html;
-        error_page_500 /errors/500.html;
+        error_page_404 errors/404.html;
+        error_page_405 errors/405.html;
+        error_page_500 errors/500.html;
     }
 
     location /
@@ -126,9 +126,9 @@ server
         root ./website;
         client_max_body_size 900000;
         index index.html;
-        error_page_404 /errors/404.html;
-        error_page_405 /errors/405.html;
-        error_page_500 /errors/500.html;
+        error_page_404 errors/404.html;
+        error_page_405 errors/405.html;
+        error_page_500 errors/500.html;
     }
 
     location /

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -63,7 +63,7 @@ class	Request {
 		std::vector<char>::iterator	getBinaryBodyEnd( void );
 
 		/* SETTERS */
-		void	setCgiFlag( bool flag);
+		void	setCgiFlag( bool flag);//public overload
 
 		std::string											getRequestLineValue( std::string key ) const;
 		std::map<std::string, std::string>::const_iterator	getHeaderBegin( void ) const;

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -81,6 +81,8 @@ class	Response {
 		void	postMethod_( void );
 
 		bool	methodAllowed_( std::string method );
+
+		/* UTILITIES FOR GET */
 		void	buildBody_( std::string& path, std::ios_base::openmode mode );
 
 		/* UTILITIES FOR POST */
@@ -97,6 +99,8 @@ class	Response {
 
 		void	setMimeType( void );
 		bool	validateResource_( void );
+
+		void	createErrorBody_( void );
 
 
 		/*TYPEDEF*/

--- a/srcs/Validator.cpp
+++ b/srcs/Validator.cpp
@@ -300,7 +300,6 @@ bool Validator::index( std::string value ){
 *  when index is checkd its value is pushed back to its server.
 */
 bool Validator::errorPage( std::string value, std::string key ){
-
 	if ( value.empty() ){
 		Logger::log(E_ERROR, COLOR_RED, "The field for index value can not be empty!");
 		return false;
@@ -319,7 +318,7 @@ bool Validator::errorPage( std::string value, std::string key ){
 		return false;
 	}
 	//push back to its server
-	servers[servers.size() - 1].setErrorPage(key, value);
+	servers[servers.size() - 1].setErrorPage(key, temp);
 	return true;
 }
 


### PR DESCRIPTION
This adds handling of provided error pages based on the config file. 
- Error pages are loaded to the response body.
- The default error page will be provided in case of no error file provided or if the file cannot be opened.

Fixes:
-  The validator class was changed to pass the whole path of the error page when `getErrorPage()` is called
-  The default config file had the leading forward slash removed on the file path provided

Other:
- additional documentation to various parts of Response class were added

