### PR TITLE
KAN-76-CGI-fd-issue-on-github

### DIFF
--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -425,8 +425,10 @@ void	ServerManager::checkIfClientTimeout( int client_fd ) {
 		if (!this->receiveFromClient(client_fd))
 			this->POLL_removeClient(client_fd);
 		else {
-			client.getResponse().createResponsePhase1(&client.getRequest());
-			if (client.getRequest().getCgiFlag() && client.getResponse().getStatusCode() < 400) {
+			Request& request = client.getRequest();
+			client.getResponse().createResponsePhase1(&request);
+
+			if (request.getComplete() && request.getCgiFlag() && client.getResponse().getStatusCode() < 400) {
 				Logger::log(E_DEBUG, COLOR_BRIGHT_MAGENTA, "valid cgi request, going to startCgiResponse");	// remove later, trying to debug heap use after free error!
 				if ((client.startCgiResponse()) == true) {
 					CgiHandler* client_cgi = client.getCgiHandler();
@@ -665,8 +667,10 @@ void	ServerManager::checkIfClientTimeout( int client_fd ) {
 		if (!this->receiveFromClient(client_fd))
 			this->SELECT_removeClient(client_fd);
 		else {
-			client.getResponse().createResponsePhase1(&client.getRequest());
-			if (client.getRequest().getCgiFlag() && client.getResponse().getStatusCode() < 400) {
+			Request& request = client.getRequest();
+			client.getResponse().createResponsePhase1(&request);
+
+			if (request.getComplete() && request.getCgiFlag() && client.getResponse().getStatusCode() < 400) {
 				if ((client.startCgiResponse()) == true) {
 					CgiHandler* client_cgi = client.getCgiHandler();
 					this->addClientCgiFdsToCgiMap_(client_fd, client_cgi->getPipeIn()[1], client_cgi->getPipeOut()[0]);


### PR DESCRIPTION
The cgi pipe issue was solved.

The problem was the following:
If the data was chunked, the server was supposed to still get more of the request until everything was received after which a response was created. There was an issue though where the cgi response and its pipes were created when the request was not yet complete which caused the cgi response to be started MULTIPLE TIMES.

This caused cascading issues which resulted in that not all the pipe fds would be removed from the pollfds (or fd_sets).

The fix was simple:
I simply added ServerManager::POLL (or SELECT)_receiveFromClient to check that the request was complete before going to the startCgiResponse function!