### PR TITLE
KAN-80-make-servermanager-check-write-and-read-at-the-same-time

### DIFF
--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -65,6 +65,7 @@ class	ServerManager {
 		int		SELECT_getBiggestFd( int max_fd_size );
 		bool	SELECT_runServers( void );
 		void	SELECT_runServersLoopStart( timeval& select_timeout, fd_set& read_fd_set_copy, fd_set& write_fd_set_copy );
+		void	SELECT_handleEvent( int fd, fd_set& read_fd_set_copy, fd_set& write_fd_set_copy );
 		void	SELECT_acceptNewClientConnection( int server_fd );
 		void	SELECT_removeFdFromSets( int fd );
 		void	SELECT_removeClient( int client_fd );
@@ -79,6 +80,7 @@ class	ServerManager {
 
 		bool	POLL_initializeServers( void );
 		bool	POLL_runServers( void );
+		void	POLL_handleEvent( std::vector<pollfd>::iterator& it );
 		void	POLL_acceptNewClientConnection( int server_fd );
 		void	POLL_removeFdFromPollfds( int fd );
 		void	POLL_removeClient( int client_fd );


### PR DESCRIPTION
Created handleEvent funcs and refactored runServers so that read and write operations are handled the same time (cone for evaluation form)