### PR TITLE
KAN-75 Limit body size of request

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -22,7 +22,6 @@ class	Request {
 		bool								cgi_flag_;
 		bool								headers_complete;
 		bool								complete_;
-		bool								sever_error_;
 		std::map<std::string, std::string>	request_line_;
 		std::map<std::string, std::string>	headers_;
 		std::string							raw_body_;

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -74,6 +74,7 @@ class	Response {
 		std::string 	contentLengthHeader_( void ) const;
 		std::string		contentLocationHeader_( void ) const;
 		std::string		locationHeader_( void ) const;
+		std::string		retryAfterHeader_( void ) const;
 
 		/* METHODS */
 		void	getMethod_( void );
@@ -99,7 +100,6 @@ class	Response {
 
 		void	setMimeType( void );
 		bool	validateResource_( void );
-
 		void	createErrorBody_( void );
 
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -15,8 +15,7 @@ chunked_(false),
 keep_alive_(false), 
 cgi_flag_(false), 
 headers_complete(false), 
-complete_(false), 
-sever_error_(false), 
+complete_(false),  
 raw_body_(""), 
 processed_body_(""),
 file_content_(""),
@@ -120,7 +119,7 @@ void	Request::add( char* to_add, size_t bytes_read ) {
 		if (!ss.eof()) {
 			std::streampos	body_start = ss.tellg();
 			if (static_cast<int>(body_start) == -1) {
-				this->sever_error_ = true;
+				this->status_code_ = 500;
 			}
 			else {
 				if (static_cast<int>(body_start) != static_cast<int>(bytes_read))
@@ -135,7 +134,7 @@ void	Request::add( char* to_add, size_t bytes_read ) {
 	}
 	catch (const std::exception& e) {
 		Logger::log(E_ERROR, COLOR_RED, "Request::add caught exception: %s", e.what());
-		this->sever_error_ = true;
+		this->status_code_ = 500;
 	}
 	std::cout << "*** BODY LEN VS RECEIVED [add] : " << this->body_size_ << " vs. " << this->body_len_received_ << std::endl;
 	// printRequest();//debugging
@@ -160,7 +159,6 @@ void	Request::clear( void ) {
 	this->processed_body_ = "";
 	this->body_vector_.clear();
 	this->complete_ = false;
-	this->sever_error_ = false;
 	this->file_upload_ = false;
 	this->file_mime_ = "";
 	this->status_code_ = 0;
@@ -273,16 +271,6 @@ bool	Request::getKeepAlive( void ) const {
 bool	Request::getComplete( void ) const {
 
 	return (this->complete_);
-}
-
-/*! \brief returns bool if there was a server error
-*
-*	Returns bool if there was a server error while processing the request.
-*  
-*/
-bool	Request::getServerError( void ) const {
-	
-	return (this->sever_error_);
 }
 
 /*! \brief returns the request line value for the key passed

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -116,6 +116,7 @@ void	Response::createResponsePhase1( Request* request ) {
 	}
 	if (this->server_->getClientMaxBodySize() < static_cast<int>(request->getBodySize())) {
 		this->status_code_ = 413; //413 Content Too Large
+		return ;
 	}
 	if (this->request_ == NULL || !this->request_->getComplete()) {
 		if (this->request_ != NULL && this->request_->getChunked()) {

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -181,9 +181,10 @@ std::string&	Response::buildAndGetResponsePhase2( void ) {
 *			reference to the response string built.
 *       
 *
-*	Builds and returns response, checking if there has been an error, adding headers as 
-*	required, and appending the body passed to the function. All are separated by the 
-*	CRLF or "/r/n" per HTTP guidelines.
+*	If the cgi process has run with out error, the body from the cgi is returned as 
+*	the full response. If the status code indicates an error, this will builds and returns 
+*	response, adding headers as required, and appending the body passed to the function. 
+*	All are separated by the CRLF or "/r/n" per HTTP guidelines.
 *  
 */
 std::string&	Response::buildAndGetResponsePhase2( const std::string& body ) {
@@ -192,6 +193,9 @@ std::string&	Response::buildAndGetResponsePhase2( const std::string& body ) {
 
 	if (this->status_code_ == 202) { //don't send anything if not ready yet
 		return this->response_;
+	}
+	if (this->status_code_ < 400) {
+		return this->body_;
 	}
 	this->response_ = ResponseCodes::getCodeStatusLine(this->status_code_);
 	if (this->status_code_ >= 400 || this->status_code_ == 0) {


### PR DESCRIPTION
This PR adds checking of client body length to response phase1 along with a retry after header for this status alone (can be expanded in the future for e.g. Too Many Requests or Request timeout

Also:
- removed references and attribute for server error in request, all status codes handled in the status_code_ attribute
- Added a call to set the mime type of cgi-script run POST requests