### PR TITLE
Kan 78 integrate url decoder into request

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -500,6 +500,8 @@ void	Request::setRequestAttributes( void ) {
 *
 *	Stores request line values in map. if method not implemented or HTTP version
 *	is not supported the status code will be set and the parsing stops.
+*	The uri as recieved is stored under "raw_uri" and the url decoded uri is stored
+*	under "uri" in the request_line_ map.
 *  
 */
 void	Request::parseRequestLine_( std::string& to_parse ) {

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -515,7 +515,7 @@ void	Request::parseRequestLine_( std::string& to_parse ) {
 		this->request_line_["method"] = part;
 	}
 	else {
-		this->status_code_ = 501; //not implemented
+		this->status_code_ = 501; //not implemented 
 		return ;
 	}
 	ss >> part;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -519,7 +519,8 @@ void	Request::parseRequestLine_( std::string& to_parse ) {
 		return ;
 	}
 	ss >> part;
-	this->request_line_["uri"] = part;
+	this->request_line_["raw_uri"] = part;
+	this->request_line_["uri"] = urlDecode(part);
 	ss >> part;
 	if (part != "HTTP/1.1") {
 		this->status_code_ = 505; //HTTP version not supported


### PR DESCRIPTION
Added in the URL decoding in the Request class for the URI. Both the raw and decoded url are stored int he request line map and can be accessed with the keys "raw_uri" and "uri". All current usage is under `uri` so that was maintained as the one to use in the decoded state. If needed the raw uri can be accessd.

Documentation updated.