### PR TITLE
add verification of server and request host match. methods added to c…

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -39,6 +39,7 @@ class	Client {
 
 		// setters
 		void					setLatestTime( void );
+		void					setServerAndFd( Server* server, int new_server_fd );
 
 		// getters
 		int						getFd( void ) const;

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -22,6 +22,8 @@ class	Request {
 		bool								cgi_flag_;
 		bool								headers_complete;
 		bool								complete_;
+		std::string							host_name_;
+		int									port_;
 		std::map<std::string, std::string>	request_line_;
 		std::map<std::string, std::string>	headers_;
 		std::string							raw_body_;
@@ -49,6 +51,7 @@ class	Request {
 		void	setKeepAlive( void );
 		void	setRequestAttributes( void );
 		void	setCgiFlag( void );
+		void	setHostNameAndPort( void );
 
 	public:
 		Request( void );
@@ -64,13 +67,15 @@ class	Request {
 		void	printRequest( void ) const;
 
 		/* GETTERS */
-		size_t		getBodySize( void ) const;
-		size_t		getBodyLengthReceived( void ) const;
-		bool		getChunked( void ) const;
-		bool		getKeepAlive( void ) const;
-		bool		getComplete( void ) const;
-		bool		getServerError( void ) const;
-		bool		getCgiFlag( void ) const;
+		size_t				getBodySize( void ) const;
+		size_t				getBodyLengthReceived( void ) const;
+		bool				getChunked( void ) const;
+		bool				getKeepAlive( void ) const;
+		bool				getComplete( void ) const;
+		bool				getServerError( void ) const;
+		bool				getCgiFlag( void ) const;
+		const std::string&	getRequestHostName( void ) const;
+		int					getRequestPort( void ) const;
 
 		std::string											getRequestLineValue( std::string key ) const;
 		std::map<std::string, std::string>::const_iterator	getHeaderBegin( void ) const;

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -131,7 +131,8 @@ class	Response {
 		const std::string&		getUploadData( void );
 
 		/* SETTERS */
-		void				setStatusCode( unsigned int	new_code );
+		void			setStatusCode( unsigned int	new_code );
+		void			setServer( Server* server );
 };
 
 #endif

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -58,6 +58,9 @@ class	ServerManager {
 		bool	sendResponseToClient( int client_fd );
 		int		getClientFdByItsCgiPipeFd( int pipe_fd );
 		void	checkIfClientTimeout( int client_fd );
+		void	checkServerAssignmentBasedOnRequest( Client& client );//
+
+		int		getServerFdFromServerMap( Server* server ) const;
 
 
 		bool	SELECT_initializeServers( void );

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -170,6 +170,15 @@ void	Client::setLatestTime( void ) {
 	time(&this->latest_time_);
 }
 
+void	Client::setServerAndFd( Server* new_server, int new_server_fd ) {
+
+	if (new_server) {
+		this->server_ = new_server;
+		this->server_fd_ = new_server_fd;
+		this->response_.setServer(this->server_);
+	}
+}
+
 // getters
 int	Client::getFd( void ) const {
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -15,7 +15,9 @@ chunked_(false),
 keep_alive_(false), 
 cgi_flag_(false), 
 headers_complete(false), 
-complete_(false),  
+complete_(false), 
+host_name_(""),
+port_(0), 
 raw_body_(""), 
 processed_body_(""),
 file_content_(""),
@@ -71,6 +73,8 @@ Request&	Request::operator=( const Request& rhs ) {
 		this->processed_body_ = rhs.processed_body_;
 		this->body_vector_ = rhs.body_vector_;
 		this->complete_ = rhs.complete_;
+		this->host_name_ = rhs.host_name_;
+		this->port_ = rhs.port_;
 		this->cgi_flag_ = rhs.cgi_flag_;
 		this->file_upload_ = rhs.file_upload_;
 		this->file_mime_ = rhs.file_mime_;
@@ -106,7 +110,8 @@ void	Request::add( char* to_add, size_t bytes_read ) {
 				this->parseRequestLine_(line);
 			}
 			else if (line.compare("\r") == 0) {
-					this->headers_complete = true;
+				this->headers_complete = true;
+				this->setRequestAttributes();
 			}
 			else {
 				this->parseHeader_(line);
@@ -114,7 +119,6 @@ void	Request::add( char* to_add, size_t bytes_read ) {
 			if (this->status_code_ > 0)
 				return ; //stop processing if error found
 		}
-		this->setRequestAttributes();
 		//process body
 		if (!ss.eof()) {
 			std::streampos	body_start = ss.tellg();
@@ -210,6 +214,26 @@ void	Request::printRequest( void ) const {
 }
 
 /************** PUBLIC GETTERS **************/
+
+/*! \brief returns const reference tot the hostname from the Host header
+*
+*	Returns const reference tot the hostname from the Host header
+*  
+*/
+const std::string&	Request::getRequestHostName( void ) const {
+
+	return this->host_name_;
+}
+
+/*! \brief returns bool indicating if this request is for a cgi script
+*
+*	Returns bool indicating if this request is for a cgi script.
+*  
+*/
+int	Request::getRequestPort( void ) const {
+
+	return this->port_;
+}
 
 /*! \brief returns bool indicating if this request is for a cgi script
 *
@@ -467,9 +491,10 @@ void	Request::setKeepAlive( void ) {
 	}
 }
 
-/*! \brief 
+/*! \brief private setter for the cgi flag. Sets bool based on uri
 *
-*	
+*	Private setter for the cgi flag. Sets bool true if uri begins with 
+*	`/cgi-bin'.
 *  
 */
 void	Request::setCgiFlag( void ) {
@@ -483,6 +508,27 @@ void	Request::setCgiFlag( void ) {
 	}
 }
 
+/*! \brief private setter for the host name and port based on Host Header
+*
+*	Private setter for the the host name and port based on Host Header
+*  
+*/
+void	Request::setHostNameAndPort( void ) {
+
+	std::string	host_header = getHeaderValueByKey("Host");
+	if (host_header.empty()) {
+		this->status_code_ = 400; //invalid request
+		return ;
+	}
+	std::string	request_host_name;
+	std::string request_port;
+	int	last_colon_pos = host_header.find_last_of(':');
+
+	this->host_name_ = host_header.substr(0, last_colon_pos);
+	this->port_ = ft_stoi(host_header.substr(last_colon_pos + 1));
+	Logger::log(E_DEBUG, COLOR_BRIGHT_BLUE, "Request Host Name: %s, Request Port: %d", this->host_name_.c_str(), this->port_);
+}
+
 /*! \brief calls all private setters to intialize request attibutes based on headers
 *
 *	Calls all private setters to intialize request attibutes based on headers.
@@ -490,8 +536,8 @@ void	Request::setCgiFlag( void ) {
 */
 void	Request::setRequestAttributes( void ) {
 
-	void	(Request::*setters[])(void) = { &Request::setKeepAlive, &Request::setChunked, &Request::setBodySize , &Request::setCgiFlag };
-	for (int i = 0; i < 4; i++) { //get size of setters instead of 3
+	void	(Request::*setters[])(void) = { &Request::setKeepAlive, &Request::setChunked, &Request::setBodySize , &Request::setCgiFlag, &Request::setHostNameAndPort };
+	for (int i = 0; i < 5; i++) { //get size of setters instead of 3
 		(this->*setters[i])();
 	}
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -231,16 +231,7 @@ void	Response::clear( void ) { 	/* reset for next use */
 	this->directory_listing_ = false;
 }
 
-/*! \brief	returns http status code set for the response
-*
-*
-*	returns http status code set for the response
-*
-*/
-int	Response::getStatusCode( void ) const {
-
-	return (this->status_code_);
-}
+/******************************* SETTERS ******************************/
 
 /*! \brief	setter for the response status code
 *
@@ -252,6 +243,27 @@ void	Response::setStatusCode( unsigned int	new_code ) {
 
 	this->status_code_ = new_code;
 }
+
+void	Response::setServer( Server* server ) {
+
+	if (server) {
+		this->server_ = server;
+	}
+}
+
+/******************************* GETTERS ******************************/
+
+/*! \brief	returns http status code set for the response
+*
+*
+*	returns http status code set for the response
+*
+*/
+int	Response::getStatusCode( void ) const {
+
+	return (this->status_code_);
+}
+
 
 /*! \brief returns the filepath to the requested resource
 *

--- a/srcs/Validator.cpp
+++ b/srcs/Validator.cpp
@@ -120,7 +120,7 @@ bool Validator::validIpHostBuilder(){
 		}
 		// Convert the IP address to a readable format
 		inet_ntop(rp->ai_family, addr, ipstr, sizeof(ipstr));
-		validIpHostMap.insert(std::make_pair(hostname, std::string(ipstr)));
+		validIpHostMap.insert(std::make_pair(std::string(ipstr), hostname));
 	}
     // Free allocated memory
     freeaddrinfo(result);
@@ -1082,7 +1082,7 @@ bool Validator::checkListenServernameUniqueness(){
 				Logger::log(E_ERROR, COLOR_RED, "Same severnames can not be listening on same listening ports!");
 				return false;
 			}
-			similars[similars.size() - 1] = temp;
+			similars.push_back(temp);
 		}
 	}
 	return true;


### PR DESCRIPTION
This PR adds verification and changing of server assigned to client based on Request header `Host`. Changes include:

Client:
- method added to change assigned server and fd (need to eval if client needs to know the server fd as it doesn't seem to be used), this further calls the method to change the response server.

Response:
- Methods were added to change the server assigned to the request (if null is passed nothing will happen)
- reorganized some functions, content not changed

Request:
- attributes added to track the request host name and port
     - a private setter for both and a getter for each was added
- Request attribute setting was moved to be once all headers are complete so it is not called more than once

ServerManager:
- method for checking the server assignment and changing the server with the client method used after recv call
- added function to find server fd from the server (might not be needed, especially if client can lose the server fd)

Validator:
- includes fix from Azär for adding computer hostname and ip correctly
- fixes segfault in the function that checks for duplicate port and hostnames, using push_back for the vector instead of indexing