### PR TITLE
KAN-96 add check for save_dir in server POST method, also add rejecti…

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -78,7 +78,7 @@ class	Response {
 		std::vector<std::string>	getAcceptedFormats( void );
 
 		/* UTILITIES FOR POST */
-		void	saveBodyToFile( void );
+		void	saveBodyToFile( bool is_save_dir );
 		
 		/* RESOURCE AND LOCATION IDENTIFICATION */
 		int		setResourceLocationAndName( std::string uri );


### PR DESCRIPTION
Small PR to add the server's handling of POST to check for the save_dir. Tested with and without save_dir set.
 
Also added the check for empty filename.