### PR TITLE
fix alias method checking

### DIFF
--- a/config/good/default.conf
+++ b/config/good/default.conf
@@ -29,8 +29,9 @@ server
 
     location /cat
     {
-		allow_methods GET POST DELETE HEAD;
+		allow_methods HEAD;
 		index index.html;
+        autoindex off;
 	}
 
 	location /add_post
@@ -46,7 +47,8 @@ server
 
 	location /pishoo
     {
-        autoindex on;
+        autoindex off;
+        allow_methods GET POST DELETE HEAD;
         alias /cat;
     }
     

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -710,11 +710,13 @@ int	Response::setResourceLocationAndName_( std::string uri ) {
 bool	Response::methodAllowed_( std::string method ) {
 
 	const std::vector<std::string>*	methods;
+	const std::vector<std::string>*	aliased_loc_methods;
 	
-	this->alias_ ? 
-	methods = this->server_->getLocationValue(this->alias_location_, "allow_methods") 
-	: methods = this->server_->getLocationValue(this->resource_location_, "allow_methods");
-	
+	methods = this->server_->getLocationValue(this->resource_location_, "allow_methods") ;
+	if (this->alias_)
+		aliased_loc_methods = this->server_->getLocationValue(this->resource_location_, "allow_methods");
+	if (methods->empty())
+		methods = aliased_loc_methods;
 	if (!methods || methods->empty()) {
 		return false;
 	}


### PR DESCRIPTION
changed how the methods are checked when an alias is present. The location that has the alias key in it should be able to override the other locations settings.